### PR TITLE
Fix Bintray URLs in README

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -147,7 +147,7 @@ Add Bintray JCenter repository to <repositories> section:
 ```
 <repository>
     <id>central</id>
-    <url>http://jcenter.bintray.com</url>
+    <url>https://dl.bintray.com/pgutkowski/Maven</url>
 </repository>
 ```
 
@@ -175,7 +175,9 @@ Add Bintray JCenter repository:
 
 ```
 repositories {
-    jcenter()
+    maven {
+        url  "https://dl.bintray.com/pgutkowski/Maven" 
+    }
 }
 ```
 


### PR DESCRIPTION
Using the ordinary JCenter didn't work for me, I had use your username based URL t correctly download the artifacts.