### PR TITLE
Make couroutineDispatcher type in configuration generic

### DIFF
--- a/src/main/kotlin/com/github/pgutkowski/kgraphql/schema/dsl/SchemaConfigurationDSL.kt
+++ b/src/main/kotlin/com/github/pgutkowski/kgraphql/schema/dsl/SchemaConfigurationDSL.kt
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import com.github.pgutkowski.kgraphql.configuration.SchemaConfiguration
 import kotlinx.coroutines.experimental.CommonPool
+import kotlinx.coroutines.experimental.CoroutineDispatcher
 
 
 class SchemaConfigurationDSL {
@@ -13,7 +14,7 @@ class SchemaConfigurationDSL {
     var objectMapper: ObjectMapper = jacksonObjectMapper()
     var documentParserCacheMaximumSize : Long = 1000L
     var acceptSingleValueAsArray : Boolean = true
-    var coroutineDispatcher = CommonPool
+    var coroutineDispatcher: CoroutineDispatcher = CommonPool
 
     internal fun update(block : SchemaConfigurationDSL.() -> Unit) = block()
 


### PR DESCRIPTION
**Issue:**
I wanted to override the CoroutineDispatcher in the schema config. Unfortunately that is not possible because the inherited Type is "CommonPool"

**Fix:**
I changed the type explicity to "CoroutineDispatcher" so the user can override it