### PR TITLE
Include Kotlin source files in source jar.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -70,7 +70,7 @@ jacoco {
 }
 
 task sourceJar(type: Jar) {
-    from sourceSets.main.allJava
+    from sourceSets.main.allSource
 }
 
 jacocoTestReport {


### PR DESCRIPTION
The source jar generated so far is empty because gradle tries to add Java sources.