### PR TITLE
enable building graphql schema using KFunction method references

### DIFF
--- a/src/jmh/kotlin/com/github/pgutkowski/kgraphql/BenchmarkSchema.kt
+++ b/src/jmh/kotlin/com/github/pgutkowski/kgraphql/BenchmarkSchema.kt
@@ -21,6 +21,12 @@ object BenchmarkSchema {
 
     val threeResolver : ()-> ModelThree = { ModelThree("", ones.map { ModelTwo(it, it.quantity..10) }) }
 
+    object HasOneResolver {
+        fun oneResolver(): List<ModelOne> {
+            return ones
+        }
+    }
+
     fun create(block : SchemaBuilder<Unit>.()-> Unit): Schema = KGraphQL.schema {
         block()
         query("one"){
@@ -31,6 +37,9 @@ object BenchmarkSchema {
         }
         query("three"){
             resolver(threeResolver)
+        }
+        query("threeKF"){
+            resolverKF(HasOneResolver::oneResolver)
         }
     }
 }

--- a/src/main/kotlin/com/github/pgutkowski/kgraphql/schema/dsl/QueryOrMutationDSL.kt
+++ b/src/main/kotlin/com/github/pgutkowski/kgraphql/schema/dsl/QueryOrMutationDSL.kt
@@ -5,6 +5,7 @@ import com.github.pgutkowski.kgraphql.schema.model.FunctionWrapper
 import com.github.pgutkowski.kgraphql.schema.model.InputValueDef
 import com.github.pgutkowski.kgraphql.schema.model.MutationDef
 import com.github.pgutkowski.kgraphql.schema.model.QueryDef
+import kotlin.reflect.KFunction
 
 
 class QueryOrMutationDSL(
@@ -24,6 +25,8 @@ class QueryOrMutationDSL(
         functionWrapper = function
         return ResolverDSL(this)
     }
+
+    fun <T>resolverKF(function: KFunction<T>) = resolver(FunctionWrapper.on(function))
 
     fun <T>resolver(function: () -> T) = resolver(FunctionWrapper.on(function))
 

--- a/src/test/kotlin/com/github/pgutkowski/kgraphql/schema/SchemaBuilderTest.kt
+++ b/src/test/kotlin/com/github/pgutkowski/kgraphql/schema/SchemaBuilderTest.kt
@@ -162,11 +162,48 @@ class SchemaBuilderTest {
         }
 
         val actorType = tested.model.queryTypes[Actor::class]
-                ?: throw Exception("Scenario type should be present in schema")
+                ?: throw Exception("Actor type should be present in schema")
         assertThat(actorType.kind, equalTo(TypeKind.OBJECT))
         val property = actorType["linked"] ?: throw Exception("Actor should have ext property 'linked'")
         assertThat(property, notNullValue())
         assertThat(property.returnType.unwrapped().name, equalTo("Actor"))
+    }
+
+    @Test
+    fun `KFunction resolver`(){
+        val actorService = object {
+            fun getMainActor() = Actor("Little John", 44)
+            fun getActor(id: Int) = when(id) {
+                1 -> Actor("Joey", 4)
+                else -> Actor("Bobby", 5)
+            }
+        }
+
+        val tested = defaultSchema {
+            query("mainActor") {
+                resolverKF(actorService::getMainActor)
+            }
+
+            query("actorById") {
+                resolverKF(actorService::getActor)
+            }
+
+            type<Actor> {
+                property<Actor>("linked") {
+                    resolver { _ -> Actor("BIG John", 3234) }
+                }
+            }
+        }
+
+        val actorType = tested.model.queryTypes[Actor::class]
+                ?: throw Exception("Actor type should be present in schema")
+        assertThat(actorType.kind, equalTo(TypeKind.OBJECT))
+        val property = actorType["linked"] ?: throw Exception("Actor should have ext property 'linked'")
+        assertThat(property, notNullValue())
+        assertThat(property.returnType.unwrapped().name, equalTo("Actor"))
+
+        deserialize(tested.execute("{mainActor{name}}"))
+        deserialize(tested.execute("{actorById(id: 1){name}}"))
     }
 
     @Test


### PR DESCRIPTION
Many times a project already has Services with methods.  These methods can have many arguments and it is tedious to expose them.  These changes allow using KFunction method references which include all argument information and reduce boilerplate.