### PR TITLE
Allow a kotlin type to be used as graphql type and inputType

### DIFF
--- a/src/main/kotlin/com/github/pgutkowski/kgraphql/request/Variables.kt
+++ b/src/main/kotlin/com/github/pgutkowski/kgraphql/request/Variables.kt
@@ -18,13 +18,13 @@ data class Variables(
     /**
      * map and return object of requested class
      */
-    fun <T : Any> get(kClass: KClass<T>, kType: KType, key: String, transform: (value: String) -> Any?): T? {
+    fun <T : Any> get(kClass: KClass<T>, kType: KType, typeName: String?, key: String, transform: (value: String) -> Any?): T? {
         val variable = variables?.find { key == it.name }
                 ?: throw IllegalArgumentException("Variable '$key' was not declared for this operation")
 
         val isIterable = kClass.isIterable()
 
-        validateVariable(typeDefinitionProvider.typeReference(kType), variable)
+        validateVariable(typeDefinitionProvider.typeReference(kType), typeName, variable)
 
         var value = variablesJson.get(kClass, kType, key.substring(1))
         if(value == null && variable.defaultValue != null){
@@ -57,9 +57,9 @@ data class Variables(
         }
     }
 
-    fun validateVariable(expectedType: TypeReference, variable: OperationVariable){
+    fun validateVariable(expectedType: TypeReference, expectedTypeName: String?, variable: OperationVariable){
         val variableType = variable.type
-        val invalidName =  expectedType.name != variableType.name
+        val invalidName =  (expectedTypeName ?: expectedType.name) != variableType.name
         val invalidIsList = expectedType.isList != variableType.isList
         val invalidNullability = !expectedType.isNullable && variableType.isNullable && variable.defaultValue == null
         val invalidElementNullability = !expectedType.isElementNullable && variableType.isElementNullable

--- a/src/main/kotlin/com/github/pgutkowski/kgraphql/schema/execution/ArgumentTransformer.kt
+++ b/src/main/kotlin/com/github/pgutkowski/kgraphql/schema/execution/ArgumentTransformer.kt
@@ -16,11 +16,12 @@ open class ArgumentTransformer(val schema : DefaultSchema) {
 
     fun transformValue(type: Type, value: String, variables: Variables) : Any? {
         val kType = type.toKType()
+        val typeName = type.unwrapped().name
 
         return when {
             value.startsWith("$") -> {
                 variables.get (
-                        kType.jvmErasure, kType, value, { subValue -> transformValue(type, subValue, variables) }
+                        kType.jvmErasure, kType, typeName, value, { subValue -> transformValue(type, subValue, variables) }
                 )
             }
             value == "null" && type.isNullable() -> null

--- a/src/main/kotlin/com/github/pgutkowski/kgraphql/schema/structure2/SchemaCompilation.kt
+++ b/src/main/kotlin/com/github/pgutkowski/kgraphql/schema/structure2/SchemaCompilation.kt
@@ -72,7 +72,7 @@ class SchemaCompilation(
 
                 queryTypes = queryTypeProxies + enums + scalars,
                 inputTypes = inputTypeProxies + enums + scalars,
-                allTypes = queryTypeProxies + inputTypeProxies + enums + scalars,
+                allTypes = queryTypeProxies.values + inputTypeProxies.values + enums.values + scalars.values,
                 directives = definition.directives.map { handlePartialDirective(it) }
         )
         val schema = DefaultSchema(configuration, model)

--- a/src/main/kotlin/com/github/pgutkowski/kgraphql/schema/structure2/SchemaModel.kt
+++ b/src/main/kotlin/com/github/pgutkowski/kgraphql/schema/structure2/SchemaModel.kt
@@ -14,19 +14,19 @@ data class SchemaModel (
         val enums: Map<KClass<out Enum<*>>, Type.Enum<out Enum<*>>>,
         val scalars : Map<KClass<*>, Type.Scalar<*>>,
         val unions : List<Type.Union>,
-        val allTypes : Map<KClass<*>, Type>,
+        val allTypes : List<Type>,
         val queryTypes: Map<KClass<*>, Type>,
         val inputTypes: Map<KClass<*>, Type>,
         override val directives: List<Directive>
 ) : __Schema {
 
-    val allTypesByName = allTypes.values.associate { it.name to it }
+    val allTypesByName = allTypes.associate { it.name to it }
 
     val queryTypesByName = queryTypes.values.associate { it.name to it }
 
     val inputTypesByName = inputTypes.values.associate { it.name to it }
 
-    override val types: List<__Type> = allTypes.values.toList()
+    override val types: List<__Type> = allTypes.toList()
             //workaround on the fact that Double and Float are treated as GraphQL Float
             .filterNot { it is Type.Scalar<*> && it.kClass == Float::class }
             .filterNot { it.kClass?.findAnnotation<NotIntrospected>() != null }

--- a/src/test/kotlin/com/github/pgutkowski/kgraphql/integration/BaseSchemaTest.kt
+++ b/src/test/kotlin/com/github/pgutkowski/kgraphql/integration/BaseSchemaTest.kt
@@ -232,6 +232,18 @@ abstract class BaseSchemaTest {
                 }}
             }
         }
+
+        inputType<Actor>() {
+            name = "ActorInput"
+        }
+
+        mutation("createActorWithAliasedInputType") {
+            description = "create new actor from full fledged ActorInput as input type"
+            resolver { newActor: Actor ->
+                createdActors.add(newActor)
+                newActor
+            }
+        }
     }
 
     @After

--- a/src/test/kotlin/com/github/pgutkowski/kgraphql/integration/MutationTest.kt
+++ b/src/test/kotlin/com/github/pgutkowski/kgraphql/integration/MutationTest.kt
@@ -69,4 +69,12 @@ class MutationTest : BaseSchemaTest() {
         assertNoErrors(map)
         assertThat(map.extract<Map<String, Any>>("data/createActor"), equalTo(mapOf<String, Any>("howOld" to testActor.age)))
     }
+
+    @Test
+    fun `simple mutation with aliased input type`(){
+        val map = execute("mutation(\$newActor: ActorInput!) { createActorWithAliasedInputType(newActor: \$newActor) {name}}",
+            variables = "{\"newActor\": {\"name\": \"${testActor.name}\", \"age\": ${testActor.age}}}")
+        assertNoErrors(map)
+        assertThat(map.extract<Map<String, Any>>("data/createActorWithAliasedInputType"), equalTo(mapOf<String, Any>("name" to testActor.name)))
+    }
 }

--- a/src/test/kotlin/com/github/pgutkowski/kgraphql/schema/SchemaBuilderTest.kt
+++ b/src/test/kotlin/com/github/pgutkowski/kgraphql/schema/SchemaBuilderTest.kt
@@ -21,6 +21,7 @@ import org.hamcrest.CoreMatchers.equalTo
 import org.hamcrest.CoreMatchers.instanceOf
 import org.hamcrest.CoreMatchers.notNullValue
 import org.hamcrest.CoreMatchers.nullValue
+import org.hamcrest.CoreMatchers.hasItem
 import org.hamcrest.MatcherAssert
 import org.hamcrest.MatcherAssert.assertThat
 import org.junit.Test
@@ -508,5 +509,26 @@ class SchemaBuilderTest {
                 resolver { -> "test"}
             }
         }
+    }
+
+    @Test
+    fun `Schema can have same type and input type with different names`(){
+        val schema = defaultSchema {
+            inputType<InputOne>() {
+                name="TypeAsInput"
+            }
+            type<InputOne>() {
+                name="TypeAsObject"
+            }
+        }
+
+        assertThat(schema.typeByKClass(InputOne::class), notNullValue())
+        assertThat(schema.inputTypeByKClass(InputOne::class), notNullValue())
+
+        val introspection = deserialize(schema.execute("{__schema{types{name}}}"))
+        val types = introspection.extract<List<Map<String,String>>>("data/__schema/types")
+        val names = types.map {it["name"]}
+        assertThat(names, hasItem("TypeAsInput"))
+        assertThat(names, hasItem("TypeAsObject"))
     }
 }


### PR DESCRIPTION
Allows reusing the same kotlin type (with a different name attribute) in a gql type and a gql inputType.

Avoids many useless kotlin type duplication to circumvent GraphQL constraint that output types cannot be input types (even when it's totally legit).

Example use :

val schema = KGraphQL.schema {
    inputType<MyKotlinType>() {
        name="TypeAsInput"
    }
    type<MyKotlinType>() {
        name="TypeAsObject"
    }
}